### PR TITLE
add cloudinary cloud_name to the configuration

### DIFF
--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,0 +1,3 @@
+Cloudinary.config do |config|
+  config.cloud_name = "hcdr9ti7y"
+end


### PR DESCRIPTION
This PR adds the Cloudinary cloud_name mostly to ease the developer experience.

If we have a seed of the database with real content, having the cloud_name allows to run the project without any env variable.

The cloud_name is not a secret part of the Cloudinary credential as we can find it in all the public asset links.

```
https://res.cloudinary.com/hcdr9ti7y/image/upload/c_fill,g_center,h_100,w_180/v1669753550/ixoxmmhpxfsvshnmmlyr.jpg
```