### PR TITLE
🐛 fix missing description 500 for video

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -25,6 +25,10 @@ class Video < ApplicationRecord
     vimeo_url[/vimeo.com\/(\d+)/, 1]
   end
 
+  def short_description
+    description&.truncate(170, separator: ' ')
+  end
+
   private
 
   def refresh_sitemap

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -1,5 +1,5 @@
 - title video.title
-- description video.description.truncate(170, separator: ' ')
+- description video.short_description
 
 .section.section-page.video
   .container


### PR DESCRIPTION
relates to #162 

Videos not having a description generate a 500

example 
https://paris-rb.org/videos/how-music-works-using-ruby-english

## Solution

Adds a short_description with a safe operator