### PR TITLE
Improve the sponsors logo image

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,4 +2,5 @@
  *= require bootstrap_override
  *= require base
  *= require vimeo
+ *= require utilities
  */

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -15,15 +15,17 @@ body > footer p {
   text-align: center;
 
   a {
-    color: #5D2026;
+    color: #5d2026;
     padding: 0 2em;
 
-    &:hover, &:active, &:focus {
-      color: #5D2026;
+    &:hover,
+    &:active,
+    &:focus {
+      color: #5d2026;
     }
 
     &:visited {
-      color: lighten(#5D2026, 20%);
+      color: lighten(#5d2026, 20%);
     }
   }
 }
@@ -32,7 +34,7 @@ body > footer p {
   padding: 2em 0 3em;
 
   header {
-    margin-bottom: 2em;
+    margin-bottom: 3em;
   }
 }
 
@@ -40,7 +42,7 @@ body > footer p {
 .section-page,
 .section-sponsors,
 .section-talks {
-  color: #FFF;
+  color: #fff;
 }
 
 .section-guests,
@@ -56,12 +58,9 @@ body > footer p {
 }
 
 .section-ellipsis,
-.section-you {
-  color: rgb(93, 32, 38);
-}
-
+.section-you,
 .section-sponsors {
-  background-color: rgb(116, 39, 47);
+  color: rgb(93, 32, 38);
 }
 
 .section-talks {
@@ -70,19 +69,21 @@ body > footer p {
 
 .section-guests {
   cite p {
-    font-size: .9em;
+    font-size: 0.9em;
     font-weight: normal;
   }
 }
 
 .container {
-  h1, p {
+  h1,
+  p {
     text-align: center;
   }
 }
 
 .elm-container {
-  h1, p {
+  h1,
+  p {
     text-align: unset;
   }
 }
@@ -100,7 +101,7 @@ body > footer p {
   padding: 1em 15px 1em;
 
   small {
-    font-size: .7em;
+    font-size: 0.7em;
   }
 }
 
@@ -111,9 +112,9 @@ body > footer p {
 
   p {
     text-align: left;
-    color: #CCC;
+    color: #ccc;
     font-weight: normal;
-    margin: .2em 0 1em;
+    margin: 0.2em 0 1em;
   }
 
   dl {
@@ -121,9 +122,9 @@ body > footer p {
   }
 
   dd {
-    color: #CCC;
+    color: #ccc;
     font-weight: normal;
-    margin: .2em 0 1em;
+    margin: 0.2em 0 1em;
   }
 }
 

--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -1,0 +1,26 @@
+/* This file is temporary before we transition to Tailwind */
+/* We define the same utilities as Tailwind, once we install Tailwind we can delete this file */
+.flex {
+  display: flex;
+}
+
+.items-center {
+  align-items: center
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+
+.gap-12 {
+  gap: 3rem;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,6 @@ require 'meetup/members_count'
 
 class WelcomeController < ApplicationController
   expose(:members_count) { Meetup::MembersCount.total }
-  expose(:sponsors) { Sponsor.visible }
+  expose(:sponsors) { Sponsor.latest(4) }
   expose(:tweets) { Tweet.all }
 end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -15,5 +15,6 @@
 class Sponsor < ApplicationRecord
   mount_uploader :logo, PictureUploader
 
-  scope :visible, ->{ where('until >= ? OR until IS NULL', Time.current) }
+  scope :current, ->{ where('until >= ? OR until IS NULL', Time.current) }
+  scope :latest,  -> (count) { order('until DESC').limit(count) }
 end

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -35,7 +35,7 @@
     .flex.items-center.justify-center.flex-wrap.gap-12
       - sponsors.each do |sponsor|
         - cache sponsor do
-            = link_to sponsor.website, title: sponsor.name, rel: 'nofollow', target: "_blank" do
+            = link_to sponsor.website, title: sponsor.name, target: "_blank" do
               - if sponsor.logo.present?
                 = cl_image_tag sponsor.logo, width: 200, height: 160, crop: :fit, alt: sponsor.name, srcset: "#{cl_image_path sponsor.logo, width: 400, height: 320, crop: :fit} 2x", style: "width: 200px"
               - else

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -32,16 +32,14 @@
       h1 = t('.sponsors.title')
       p = t('.sponsors.subtitle')
 
-    - sponsors.each_slice(4) do |sponsor_group|
-      .row
-        - sponsor_group.each do |sponsor|
-          - cache sponsor do
-            .sponsor.col-sm-3
-              = link_to sponsor.website, title: sponsor.name, rel: 'nofollow' do
-                - if sponsor.logo.present?
-                  = image_tag sponsor.logo.thumb.url(secure: true), alt: sponsor.name, class: 'img-thumbnail'
-                - else
-                  = sponsor.name
+    .flex.items-center.justify-center.flex-wrap.gap-12
+      - sponsors.each do |sponsor|
+        - cache sponsor do
+            = link_to sponsor.website, title: sponsor.name, rel: 'nofollow', target: "_blank" do
+              - if sponsor.logo.present?
+                = cl_image_tag sponsor.logo, width: 200, height: 160, crop: :fit, alt: sponsor.name, srcset: "#{cl_image_path sponsor.logo, width: 400, height: 320, crop: :fit} 2x", style: "width: 200px"
+              - else
+                = sponsor.name
 
 .section.section-you
   .container


### PR DESCRIPTION
Currently the sponsor images does not properly manage the different ratio of the logos (square vs 16/9)
as an example here is what it could look like currently with multiple logos. (Kard and Scalingo are cropped)

<img width="1512" alt="Screenshot 2023-01-05 at 00 58 26" src="https://user-images.githubusercontent.com/7847244/213977789-a7fa1924-e43d-406f-afa6-0a4f4afe1fe6.png">

This PR fixes that by using the built in crop feature of Cloudinary
It does also add srcset 2x for Retina display 
and lastly rather than displaying only the `visible` Sponsor I added a new scope `latest(n)` in order to always display the latest 4 sponsor on the home page. I think is is best to show the sponsor for a longer period (for them and for us) . Open to discuss that choice. 

## Result

<img width="1262" alt="Screenshot 2023-01-23 at 07 41 14" src="https://user-images.githubusercontent.com/7847244/213979566-5c601663-ac50-4062-9af2-a221184b9144.png"> 

## Technical choice

Rather than growing the sass, I started adding utilities. Those utilities have the same name has Tailwind. As part of the revamp of the site I think we will move to TW at the end so that will remain transparent once we have done this move.
