### PR TITLE
Add Tailwind and basic new layout for the redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ docker
 vendor/.bundle/
 .byebug_history
 
-
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ docker
 vendor/.bundle/
 .byebug_history
 
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "turbo-rails"
 # gem "stimulus-rails"
 
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-# gem "tailwindcss-rails"
+gem "tailwindcss-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,8 @@ GEM
     ssrf_filter (1.1.1)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
+    tailwindcss-rails (2.0.21-arm64-darwin)
+      railties (>= 6.0.0)
     temple (0.10.0)
     thor (1.2.1)
     tilt (2.0.11)
@@ -433,6 +435,7 @@ DEPENDENCIES
   slim
   sprockets-rails
   sucker_punch
+  tailwindcss-rails
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,3 +3,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action do
-    # This will need to be removed once we have transition to the new design
+    # This will need to be removed once we have transitioned to the new design
     # during the transition period we can visit any page and add ?new=true to
     # see the new design (if it exists)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,17 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action do
+    # This will need to be removed once we have transition to the new design
+    # during the transition period we can visit any page and add ?new=true to
+    # see the new design (if it exists)
+
+    if params[:new] == 'true'
+      session[:site_design] = :new
+    elsif params[:new] == 'false'
+      session[:site_design] = nil
+    end
+
+    request.variant = session[:site_design]&.to_sym
+  end
 end

--- a/app/views/layouts/application.html+new.erb
+++ b/app/views/layouts/application.html+new.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <% if ENV["GOOGLE_WEB_TOOLS_ID"] %>
+      <meta content="<%= ENV["GOOGLE_WEB_TOOLS_ID"] %>" name="google-site-verification" />
+    <% end %>
+
+    <%= display_meta_tags reverse: true, site: t('site_name'), separator: '·' %>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body>
+    <main class="container mx-auto flex flex-col">
+      <%= yield %>
+    </main>
+  </body>
+</html>
+

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/typography'),
+  ]
+}


### PR DESCRIPTION
This PR install Tailwind using the tailwind-rails gem. 

To start the project you now need to either use the Profile.dev with foreman or overwind (bin/dev will start foreman automatically) or in two different terminals `rails s` and  `rails tailwindcss:watch` 

In theory Tailwind is not added yet to the main layout. To facilitate the transition a new application layout using a (+new) variant is available. To enable this new layout you can add `?new=true` to the url to display a fully broken site 😄.

This should facilitate the migration page by page to the new design

