### PR TITLE
Better: Automatically add emoji based on talk duration on lineup

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -94,6 +94,14 @@ class Talk < ApplicationRecord
     happened_at && happened_at < Date.today
   end
 
+  def emoji
+    duration.long? ? '💬' : '⚡'
+  end
+
+  def title_with_emoji
+    "#{emoji} #{title}"
+  end
+
   def send_slack_notification!
     return if ENV['SLACK_WEBHOOK_URL'].blank?
 

--- a/app/views/lineup/_talks.slim
+++ b/app/views/lineup/_talks.slim
@@ -9,7 +9,7 @@ section
       - talks.each do |talk|
         tr
           th = talk.speaker_name
-          td = talk.title
+          td = talk.title_with_emoji
 
   p
     | [Food, Drinks, Networking] at some point ;)

--- a/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
+++ b/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
@@ -7,6 +7,8 @@ class RemoveEmojiPrefixFromTalks < ActiveRecord::Migration[7.0]
   end
 
   def down
-    Talk.all.each { _1.update!(title: _1.title_with_emoji) }
+    Talk.all.each do |talk|
+      talk.update!(title: talk.title_with_emoji)
+    end
   end
 end

--- a/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
+++ b/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
@@ -1,0 +1,9 @@
+class RemoveEmojiPrefixFromTalks < ActiveRecord::Migration[7.0]
+  def up
+    Talk.all.each { _1.update!(title: _1.title.delete_prefix('💬').delete_prefix('⚡'.strip)) }
+  end
+
+  def down
+    Talk.all.each { _1.update!(title: _1.title_with_emoji) }
+  end
+end

--- a/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
+++ b/db/migrate/20230322213633_remove_emoji_prefix_from_talks.rb
@@ -1,6 +1,9 @@
 class RemoveEmojiPrefixFromTalks < ActiveRecord::Migration[7.0]
   def up
-    Talk.all.each { _1.update!(title: _1.title.delete_prefix('💬').delete_prefix('⚡'.strip)) }
+    Talk.all.each do |talk|
+      title = talk.title.delete_prefix('💬').delete_prefix('⚡').strip
+      talk.update!(title: title)
+    end
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2017_08_12_155652) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_22_213633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
We were adding emojis based on talk duration manually to have a nice lineup, now those emojis are automatically added.

Talk list:

![Screenshot_2023-03-22_22-44-39](https://user-images.githubusercontent.com/1866809/227045416-54337063-168b-4067-8152-ba18270fba67.png)

How it is shown in lineup:

![Screenshot_2023-03-22_22-45-05](https://user-images.githubusercontent.com/1866809/227045513-2b43c014-a98b-48a5-9d28-cf6ada67a5cc.png)

