### PR TITLE
Better: order for lineup slides.

### DIFF
--- a/app/views/lineup/show.html.slim
+++ b/app/views/lineup/show.html.slim
@@ -4,11 +4,8 @@
     .logo = image_tag 'logo.png', alt: 'Rubyparis'
   .slides
     = render 'lineup/welcome'
-    = render 'lineup/sponsors'
-    = render 'lineup/talks'
     = render 'lineup/newcomers'
+    = render 'lineup/talks'
+    = render 'lineup/sponsors'
     = render 'lineup/speakers'
     = render 'lineup/social_media'
-    = render 'lineup/sponsors'
-    = render 'lineup/talks'
-    = render 'lineup/welcome'


### PR DESCRIPTION
Current slide order is strange and hard to present:

![Screenshot_2023-04-03_22-40-33](https://user-images.githubusercontent.com/1866809/229622782-be105270-0e72-4664-af4e-6aa7fb8562cd.png)

I changed it for a more natural order:

![Screenshot_2023-04-03_22-39-52](https://user-images.githubusercontent.com/1866809/229622818-c7ad9a72-116e-44c3-9de4-2791149da39e.png)

@julienmarseille I'll let you review as you'll be the one presenting them on the next meetup