### PR TITLE
Talk priorities

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -16,6 +16,7 @@
 #  speaker_twitter      :string
 #  preferred_month_talk :string
 #  time_position        :datetime
+#  priority             :string
 #
 # Indexes
 #
@@ -65,6 +66,9 @@ class Talk < ApplicationRecord
   end
 
   ALL_MONTHS = months_iterator(1..12)
+  
+  enumerize :priority,
+    in: [:low, :normal, :high], default: :normal
 
   enumerize :preferred_month_talk,
     in: ALL_MONTHS.keys.map(&:to_sym)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -35,6 +35,7 @@ RailsAdmin.config do |config|
       end
       field :title
       field :speaker_name
+      field :priority
       field :speaker_twitter
       field :preferred_month_talk
       field :time_position

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -20,6 +20,7 @@ fr:
         happened_at: Date
         level: Difficulté
         lineup: Ajouter au lineup
+        priority: Priorité
         slides: Slides
         speaker_email: Email
         speaker_name: Speaker
@@ -65,6 +66,10 @@ fr:
         easy: Débutant
         intermediate: Moyen
         expert: Expert
+      priority:
+        low: Basse
+        normal: Normale
+        high: Haute
 
   helpers:
     submit:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,6 +8,11 @@ fr:
 
   site_name: Paris.rb
 
+  admin:
+    help:
+      talk:
+        priority: Optionnel. Une priorité 'basse' peut servir à mettre de côté un talk pour combler un programme, une priorité 'haute' pour les invités spéciaux.
+
   activerecord:
     attributes:
       user:

--- a/db/migrate/20231118111323_add_priority_to_talks.rb
+++ b/db/migrate/20231118111323_add_priority_to_talks.rb
@@ -1,0 +1,5 @@
+class AddPriorityToTalks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :talks, :priority, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_22_213633) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_22_213633) do
     t.string "speaker_twitter"
     t.string "preferred_month_talk"
     t.datetime "time_position", precision: nil
+    t.string "priority"
     t.index ["happened_at"], name: "index_talks_on_happened_at"
   end
 


### PR DESCRIPTION
Since we're starting to add low-priority talks (i.e. talks that are mostly proposed to fill in a short line-up, if need be), having a clear way to point them out could be useful. And while we're at it, why not an the option of marking a talk as "high priority" so that room could be made for it (e.g. for an special guest)?

Note that this attribute is not user-facing – only admins should have the ability to decide that a talk as is low- or high-priority. By default, the priority of a talk is "normal", and this level should be kept most of time.