### PR TITLE
🐛 Fix migration

### DIFF
--- a/db/migrate/20131124225118_create_talks.rb
+++ b/db/migrate/20131124225118_create_talks.rb
@@ -1,4 +1,4 @@
-class CreateTalks < ActiveRecord::Migration
+class CreateTalks < ActiveRecord::Migration[7.0]
   def change
     create_table :talks do |t|
       t.string  :title

--- a/db/migrate/20131201175242_create_videos.rb
+++ b/db/migrate/20131201175242_create_videos.rb
@@ -1,4 +1,4 @@
-class CreateVideos < ActiveRecord::Migration
+class CreateVideos < ActiveRecord::Migration[7.0]
   def change
     create_table :videos do |t|
       t.string :vimeo_url

--- a/db/migrate/20131201202915_create_sponsors.rb
+++ b/db/migrate/20131201202915_create_sponsors.rb
@@ -1,4 +1,4 @@
-class CreateSponsors < ActiveRecord::Migration
+class CreateSponsors < ActiveRecord::Migration[7.0]
   def change
     create_table :sponsors do |t|
       t.string   :name

--- a/db/migrate/20140106172253_devise_create_users.rb
+++ b/db/migrate/20140106172253_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20140106172254_create_rails_admin_histories_table.rb
+++ b/db/migrate/20140106172254_create_rails_admin_histories_table.rb
@@ -1,4 +1,4 @@
-class CreateRailsAdminHistoriesTable < ActiveRecord::Migration
+class CreateRailsAdminHistoriesTable < ActiveRecord::Migration[7.0]
    def self.up
      create_table :rails_admin_histories do |t|
        t.text :message # title, name, or object_id

--- a/db/migrate/20140107180320_create_tweets.rb
+++ b/db/migrate/20140107180320_create_tweets.rb
@@ -1,4 +1,4 @@
-class CreateTweets < ActiveRecord::Migration
+class CreateTweets < ActiveRecord::Migration[7.0]
   def change
     create_table :tweets do |t|
       t.string :text

--- a/db/migrate/20140220114849_add_happened_at_to_talks.rb
+++ b/db/migrate/20140220114849_add_happened_at_to_talks.rb
@@ -1,4 +1,4 @@
-class AddHappenedAtToTalks < ActiveRecord::Migration
+class AddHappenedAtToTalks < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :happened_at, :date
     add_index :talks, :happened_at

--- a/db/migrate/20140221114249_add_slides_and_video_to_talks.rb
+++ b/db/migrate/20140221114249_add_slides_and_video_to_talks.rb
@@ -1,4 +1,4 @@
-class AddSlidesAndVideoToTalks < ActiveRecord::Migration
+class AddSlidesAndVideoToTalks < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :slides, :string
     add_column :talks, :video_slug, :string

--- a/db/migrate/20140224181029_rename_video_slug_to_video_url_in_talks.rb
+++ b/db/migrate/20140224181029_rename_video_slug_to_video_url_in_talks.rb
@@ -1,4 +1,4 @@
-class RenameVideoSlugToVideoUrlInTalks < ActiveRecord::Migration
+class RenameVideoSlugToVideoUrlInTalks < ActiveRecord::Migration[7.0]
   def change
     rename_column :talks, :video_slug, :video_url
   end

--- a/db/migrate/20140702174558_add_lineup_to_talks.rb
+++ b/db/migrate/20140702174558_add_lineup_to_talks.rb
@@ -1,4 +1,4 @@
-class AddLineupToTalks < ActiveRecord::Migration
+class AddLineupToTalks < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :lineup, :boolean, default: false, index: true
   end

--- a/db/migrate/20141104103459_remove_lineup_from_talks.rb
+++ b/db/migrate/20141104103459_remove_lineup_from_talks.rb
@@ -1,4 +1,4 @@
-class RemoveLineupFromTalks < ActiveRecord::Migration
+class RemoveLineupFromTalks < ActiveRecord::Migration[7.0]
   def up
     remove_column :talks, :lineup
   end

--- a/db/migrate/20170812131957_add_speaker_twitter_to_talk.rb
+++ b/db/migrate/20170812131957_add_speaker_twitter_to_talk.rb
@@ -1,4 +1,4 @@
-class AddSpeakerTwitterToTalk < ActiveRecord::Migration
+class AddSpeakerTwitterToTalk < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :speaker_twitter, :string
   end

--- a/db/migrate/20170812140829_add_preferred_talk_month_to_talk.rb
+++ b/db/migrate/20170812140829_add_preferred_talk_month_to_talk.rb
@@ -1,4 +1,4 @@
-class AddPreferredTalkMonthToTalk < ActiveRecord::Migration
+class AddPreferredTalkMonthToTalk < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :preferred_month_talk, :string
   end

--- a/db/migrate/20170812155652_add_time_to_talk.rb
+++ b/db/migrate/20170812155652_add_time_to_talk.rb
@@ -1,4 +1,4 @@
-class AddTimeToTalk < ActiveRecord::Migration
+class AddTimeToTalk < ActiveRecord::Migration[7.0]
   def change
     add_column :talks, :time_position, :datetime
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,8 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
     t.string "table"
     t.integer "month", limit: 2
     t.bigint "year"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["item", "table", "month", "year"], name: "index_rails_admin_histories"
   end
 
@@ -30,10 +30,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
     t.string "name"
     t.string "website"
     t.string "logo"
-    t.datetime "from", precision: nil
-    t.datetime "until", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "from"
+    t.datetime "until"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "talks", force: :cascade do |t|
@@ -42,14 +42,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
     t.string "speaker_email"
     t.string "level"
     t.string "duration"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.date "happened_at"
     t.string "slides"
     t.string "video_url"
     t.string "speaker_twitter"
     t.string "preferred_month_talk"
-    t.datetime "time_position", precision: nil
+    t.datetime "time_position"
     t.string "priority"
     t.index ["happened_at"], name: "index_talks_on_happened_at"
   end
@@ -59,18 +59,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
     t.string "author"
     t.string "twitter_handle"
     t.string "cool_projects"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -82,8 +82,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_18_111323) do
     t.text "description"
     t.date "event_date"
     t.string "slug"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_videos_on_slug", unique: true
   end
 


### PR DESCRIPTION
Error :

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Active Record release the migration was written for: class CreateTalks < ActiveRecord::Migration[7.0]