### PR TITLE
set the Cloudinary base folder by environment 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,10 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # In development we use local storage unless teh developer has set secret keys for cloudinary
+  # this ensure that everyone can simply clone the repo and start working without having to setup cloudinary
+  # but also allows the developer to test cloudinary locally if they have the keys
+  config.active_storage.service = ENV["CLOUDINARY_API_SECRET"].present? ? :cloudinary : :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,6 +8,7 @@ local:
 
 cloudinary:
   service: Cloudinary
+  folder: <%= (ENV["IS_REVIEW_APP"] == "true") ? "review" : Rails.env %> # each environment will have its own folder in Cloudinary
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/scalingo.json
+++ b/scalingo.json
@@ -5,6 +5,9 @@
   "env": {
     "SLACK_WEBHOOK_URL": {
       "value": null
+    },
+    "IS_REVIEW_APP": {
+      "value": "true"
     }
   }
 }


### PR DESCRIPTION
Ensure that Review App, Development and production all have their own dedicated folder in Cloudinary to avoid collisions
