### PR TITLE
🚸 Indicates to the administrator that the slug field is optional

### DIFF
--- a/app/avo/resources/video.rb
+++ b/app/avo/resources/video.rb
@@ -13,6 +13,6 @@ class Avo::Resources::Video < Avo::BaseResource
     field :vimeo_url, as: :text, hide_on: [ :index ]
     field :description, as: :textarea, hide_on: [ :index ]
     field :event_date, as: :date
-    field :slug, as: :text, hide_on: [ :index ]
+    field :slug, as: :text, hide_on: [ :index ], help: "Laissez le champs vide pour qu'il soit complété automatiquement"
   end
 end


### PR DESCRIPTION
<img width="881" alt="Capture d’écran 2024-05-09 à 16 33 07" src="https://github.com/parisrb/paris-rb.org/assets/7428736/99acdacc-b936-40ec-afd3-9680cf299dcb">
