### PR TITLE
add honeypot to talk form to prevent bot spams

### DIFF
--- a/app/controllers/concerns/captcha.rb
+++ b/app/controllers/concerns/captcha.rb
@@ -1,0 +1,35 @@
+module Captcha
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :captcha_actions, default: []
+    class_attribute :honeypot_field_name, default: "color"
+
+    before_action :verify_honeypot, if: :action_enforced?
+  end
+
+  class_methods do
+    def protect_from_spam_with_honeypot(options = {})
+      self.captcha_actions = Array(options[:only])
+      self.honeypot_field_name = options[:field_name].to_s if options[:field_name].present?
+    end
+  end
+
+  private
+
+  def verify_honeypot
+    redirect_to root_path unless honeypot_empty?
+  end
+
+  def honeypot_empty?
+    honeypot_value.blank?
+  end
+
+  def honeypot_value
+    params[honeypot_field_name]
+  end
+
+  def action_enforced?
+    captcha_actions.include?(action_name.to_sym)
+  end
+end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,4 +1,7 @@
 class TalksController < ApplicationController
+  include Captcha
+  protect_from_spam_with_honeypot only: [ :create ]
+
   def index
     @lineup_talks = Talk.lineup
   end

--- a/app/helpers/captcha_helper.rb
+++ b/app/helpers/captcha_helper.rb
@@ -1,0 +1,16 @@
+module CaptchaHelper
+  def captcha_field_tag
+    tag :input, type: "text", name: honeypot_field_name, id: honeypot_field_name, style: style
+  end
+
+  private
+
+  def honeypot_field_name
+    controller.class.honeypot_field_name
+  end
+
+  def style
+    # various ways to hide the honeypot field
+    [ "display:none;", "visibility:hidden; position: absolute;", "position:absolute; top:-9999px; left:-9999px;", "height:0; width:0; opacity:0;" ].sample
+  end
+end

--- a/app/views/talks/_form.html.erb
+++ b/app/views/talks/_form.html.erb
@@ -36,6 +36,9 @@
       <%= f.label :level, class: 'label' %>
       <%= f.select :level, Talk.level.options, {}, { class: 'select select-bordered w-full' } %>
     </div>
+
+    <%# honeypot captcha field to detect bots %>
+    <%= captcha_field_tag %>
   </div>
 
   <div class="flex flex-col gap-4 mt-6 items-start">

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -31,4 +31,13 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to talks_path
   end
+
+  test "should detect bots with an honeypot field" do
+    @talk.preferred_month_talk = Talk.propose_upcoming_months.keys.sample
+    assert_no_difference("Talk.count") do
+      post talks_url, params: { talk: @talk.attributes.except("id", "created_at", "updated_at"), color: "honey" }
+    end
+
+    assert_redirected_to root_path
+  end
 end


### PR DESCRIPTION
We are getting quite a few spam talks proposal
This PR adds a simple visually hidden field to the talks#form to identify bots and ignore them when this field is filed (honeypot strategy)

