### PR TITLE
✨ Ajoute un lien de redirection vers le lien Slack

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,11 +61,4 @@ module ApplicationHelper
       concat content
     end
   end
-
-  def linkedin_url = "https://www.linkedin.com/company/paris-rb/"
-  def twitch_url = "https://www.twitch.tv/paris_rb"
-  def youtube_url = "https://www.youtube.com/@paris-rb"
-  def meetup_url = "https://www.meetup.com/paris_rb/"
-  def github_url = "https://github.com/parisrb/paris-rb.org"
-  def join_slack_url = "https://join.slack.com/t/parisrb/shared_invite/zt-2gqmx0xph-guw535snhYofUjjB9rNvCQ"
 end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -9,23 +9,23 @@
       <div class="text-center font-extralight mb-6">Meetup Ruby depuis 2011</div>
       <div><%= t("welcome.index.join_us_on") %></div>
       <div class="flex flex-wrap items-center gap-4 justify-center">
-        <%= link_to join_slack_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+        <%= link_to JOIN_SLACK_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
           <%= lucide_icon "slack", class: 'h-6 w-6' %>
           Slack
         <% end %>
         <!-- Youtube -->
-        <%= link_to youtube_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+        <%= link_to YOUTUBE_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
           <%= lucide_icon "youtube", class: 'h-6 w-6' %>
           Youtube
         <% end %>
         <!-- Twitch -->
-        <%= link_to twitch_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+        <%= link_to TWITCH_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
           <%= lucide_icon "twitch", class: 'h-6 w-6' %>
           Twitch
         <% end %>
 
         <!-- Linkedin -->
-        <%= link_to linkedin_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+        <%= link_to LINKEDIN_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
           <%= lucide_icon "linkedin", class: 'h-6 w-6' %>
           Linkedin
         <% end %>
@@ -33,9 +33,9 @@
     </div>
   </div>
   <div class="flex flex-wrap justify-center gap-8 mt-8">
-    <%= external_link_to "Code source", github_url, class: "link" %>
+    <%= external_link_to "Code source", GITHUB_URL, class: "link" %>
     <%= link_to "Mentions légales", page_path("legals"), class: "link" %>
     <%= link_to "Code de conduite", page_path("code_de_conduite"), class: "link" %>
-    <%= external_link_to "Meetup", meetup_url, class: "link" %>
+    <%= external_link_to "Meetup", MEETUP_URL, class: "link" %>
   </div>
 </footer>

--- a/app/views/lineups/_social_media.html.erb
+++ b/app/views/lineups/_social_media.html.erb
@@ -7,23 +7,23 @@
   <div class="flex flex-wrap gap-8 justify-center items-center">
     <div class="flex flex-col gap-4 justify-center items-center">
       <%= image_tag "twitch.jpg", class: "h-20 w-auto" %>
-      <div><%= link_to 'twitch.tv/paris_rb', 'https://www.twitch.tv/paris_rb', target: "_blank" %></div>
+      <div><%= link_to 'twitch.tv/paris_rb', TWITCH_URL, target: "_blank" %></div>
     </div>
     <div class="flex flex-col gap-4 justify-center items-center">
       <%= image_tag "youtube.png", class: "h-20 w-auto" %>
-      <div><%= link_to 'youtube.com/@paris-rb', 'https://www.youtube.com/@paris-rb', target: "_blank" %></div>
+      <div><%= link_to 'youtube.com/@paris-rb', YOUTUBE_URL, target: "_blank" %></div>
     </div>
     <div class="flex flex-col gap-4 justify-center items-center">
       <%= image_tag "slack.png", class: "h-20 w-auto" %>
-      <div><%= link_to 'Join Slack', 'https://join.slack.com/t/parisrb/shared_invite/zt-2gqmx0xph-guw535snhYofUjjB9rNvCQ', target: "_blank" %></div>
+      <div><%= link_to 'Join Slack', JOIN_SLACK_URL, target: "_blank" %></div>
     </div>
     <div class="flex flex-col gap-4 justify-center items-center">
       <%= image_tag "meetup.png", class: "h-20 w-auto" %>
-      <div><%= link_to 'meetup.com/paris_rb', 'https://www.meetup.com/paris_rb/', target: "_blank" %></div>
+      <div><%= link_to 'meetup.com/paris_rb', MEETUP_URL, target: "_blank" %></div>
     </div>
     <div class="flex flex-col gap-4 justify-center items-center">
       <%= image_tag "linkedin.svg", class: "h-20 w-auto" %>
-      <div><%= link_to 'linkedin.com/company/paris-rb', 'https://www.linkedin.com/company/paris-rb', target: "_blank" %></div>
+      <div><%= link_to 'linkedin.com/company/paris-rb', LINKEDIN_URL, target: "_blank" %></div>
     <div>
   </div>
 </section>

--- a/app/views/talks/new.html.erb
+++ b/app/views/talks/new.html.erb
@@ -5,7 +5,7 @@
   <h1 class="text-center mb-12 text-primary"><%= t('.title') %></h1>
 
   <div class="flex flex-col gap-12 max-w-2xl mx-auto">
-    <div><%= t(".description_html", link: external_link_to("#orga", join_slack_url, class: "link inline-block")) %></div>
+    <div><%= t(".description_html", link: external_link_to("#orga", JOIN_SLACK_URL, class: "link inline-block")) %></div>
     <%= render 'form', talk: @talk %>
     <div class="prose max-w-none">
       <%= render "talks/questions_and_answers" %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -12,7 +12,7 @@
           <div><%= t('.subtitle_2_html') %></div>
         </div>
         <div class="flex flex-col sm:flex-row items-center gap-2">
-          <%= external_link_to t('.hero_cta'), meetup_url, class: "btn btn-secondary", target: "_blank" %>
+          <%= external_link_to t('.hero_cta'), MEETUP_URL, class: "btn btn-secondary", target: "_blank" %>
           <div class="flex gap-2">
             <span><%= t("or") %></span>
             <%= link_to t(".suggest_talk"), new_talk_path, class: "link link-primary" %>
@@ -21,26 +21,26 @@
         <div class="flex items-center gap-2 mt-8 flex-wrap">
           <%= t(".join_us_on") %>
           <!-- Slack -->
-          <%= link_to join_slack_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+          <%= link_to JOIN_SLACK_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
             <%= lucide_icon "slack", class: 'h-6 w-6' %>
             Slack
           <% end %>
           <%= lucide_icon "slash", class: "h-4 w-4" %>
           <!-- Youtube -->
-          <%= link_to youtube_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+          <%= link_to YOUTUBE_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
             <%= lucide_icon "youtube", class: 'h-6 w-6' %>
             Youtube
           <% end %>
           <%= lucide_icon "slash", class: "h-4 w-4" %>
           <!-- Twitch -->
-          <%= link_to twitch_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+          <%= link_to TWITCH_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
             <%= lucide_icon "twitch", class: 'h-6 w-6' %>
             Twitch
           <% end %>
 
           <%= lucide_icon "slash", class: "h-4 w-4" %>
           <!-- Linkedin -->
-          <%= link_to linkedin_url, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
+          <%= link_to LINKEDIN_URL, class: "flex items-center gap-2 link link-primary", target: "_blank" do %>
             <%= lucide_icon "linkedin", class: 'h-6 w-6' %>
             Linkedin
           <% end %>

--- a/config/initializers/social_links.rb
+++ b/config/initializers/social_links.rb
@@ -1,0 +1,6 @@
+LINKEDIN_URL = "https://www.linkedin.com/company/paris-rb/"
+TWITCH_URL = "https://www.twitch.tv/paris_rb"
+YOUTUBE_URL = "https://www.youtube.com/@paris-rb"
+MEETUP_URL = "https://www.meetup.com/paris_rb/"
+GITHUB_URL = "https://github.com/parisrb/paris-rb.org"
+JOIN_SLACK_URL = "https://join.slack.com/t/parisrb/shared_invite/zt-2gqmx0xph-guw535snhYofUjjB9rNvCQ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resource :locale, only: [ :update ]
 
   get "/communique_2022" => redirect("/communiques/thibault_assus_comdamnation", status: 301)
+  get "/redirection/slack" => redirect(JOIN_SLACK_URL, status: 308)
 
   root to: "welcome#index"
 end

--- a/test/controllers/redirection_controller_test.rb
+++ b/test/controllers/redirection_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class RedirectionControllerTest < ActionDispatch::IntegrationTest
+  test "should redirect /redirection/slack to Slack URL with status 308" do
+    get "/redirection/slack"
+    assert_redirected_to JOIN_SLACK_URL
+    assert_response :permanent_redirect
+  end
+end


### PR DESCRIPTION
Les liens d'invitations Slack ne durent plus que 30J : https://parisrb.slack.com/archives/C08PRJANL/p1749642499848269

- https://github.com/parisrb/paris-rb.org/issues/292

L'idée est d'avoir un lien toujours valide qui redirige (status 308) vers le bon lien afin de pouvoir avoir un lien qui reste toujours valide