### PR TITLE
Fix non-URLs in database.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   arm64-darwin-25
   x86_64-darwin-20
   x86_64-linux

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,6 @@ default: &default
 development:
   <<: *default
   database: paris_rb_development
-  url: <%= ENV["DATABASE_URL_TEST"] %>
 
 test:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,7 +10,6 @@ development:
 test:
   <<: *default
   database: paris_rb_test
-  url: <%= ENV["DATABASE_URL_TEST"] %>
 
 production:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,11 +5,13 @@ default: &default
 
 development:
   <<: *default
-  url: <%= ENV.fetch("DATABASE_URL", "paris_rb_development") %>
+  database: paris_rb_development
+  url: <%= ENV["DATABASE_URL_TEST"] %>
 
 test:
   <<: *default
-  url: <%= ENV.fetch("DATABASE_URL_TEST", "paris_rb_test") %>
+  database: paris_rb_test
+  url: <%= ENV["DATABASE_URL_TEST"] %>
 
 production:
   <<: *default

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require "open-uri"
+
 User.create_with(password: 'password').find_or_create_by!(email: 'admin@example.org')
 
 puts "Creating sponsors"


### PR DESCRIPTION
The `super(key.to_sym)` error occurs because `url: paris_rb_development` is missing a URL scheme.