### PR TITLE
remove sucker punch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,6 @@ gem "meta-tags"
 gem "rails-i18n"
 gem "ransack"
 gem "sitemap_generator", require: false
-gem "sucker_punch"
 
 gem "ahoy_matey", "~> 5.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,8 +419,6 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    sucker_punch (3.2.0)
-      concurrent-ruby (~> 1.0)
     thor (1.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.17)
@@ -497,7 +495,6 @@ DEPENDENCIES
   sitepress-rails
   sprockets-rails
   stimulus-rails
-  sucker_punch
   turbo-rails
   tzinfo-data
   web-console

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,2 @@
 class ApplicationJob < ActiveJob::Base
-  include SuckerPunch::Job
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,8 +42,8 @@ module RubyparisOrg
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :fr
 
-    # User sucker_punch as Active Job adapter
-    config.active_job.queue_adapter = :sucker_punch
+    # We don't have any heavy background jobs, so we can use the async adapter
+    config.active_job.queue_adapter = :async
 
     config.generators do |g|
       g.test_framework :test_unit, fixture: true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,4 +63,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
SuckerPunch can ([and should](https://github.com/brandonhilkert/sucker_punch?tab=readme-ov-file#faq)) now be replaced by the built in Async adapter.

To fix the error we had the test now uses the `:test` queue adapter


Edit : Rails 7.2 live version here https://rubyparis-pr302.osc-fr1.scalingo.io/