### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ci-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/parisrb/paris-rb.org/security/code-scanning/10](https://github.com/parisrb/paris-rb.org/security/code-scanning/10)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `concurrency` and before `jobs`) so all jobs inherit minimal token scope unless overridden.  
For this workflow, the best minimal non-breaking setting is:

- `contents: read`

This preserves existing functionality (checkout and read-only CI tasks) while documenting and enforcing least privilege. No imports, methods, or extra definitions are needed—just YAML config update in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
