### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ci-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/parisrb/paris-rb.org/security/code-scanning/9](https://github.com/parisrb/paris-rb.org/security/code-scanning/9)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal required token scope. The best non-breaking default here is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI operations while documenting intent and preventing broader permissions if repository defaults change. Place it near the top-level keys (after `concurrency` and before `jobs`, or before `jobs` generally). No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
