### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ci-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/parisrb/paris-rb.org/security/code-scanning/11](https://github.com/parisrb/paris-rb.org/security/code-scanning/11)

Add an explicit workflow-level `permissions` block so all jobs inherit least-privilege token access.

Best fix here (without changing functionality): in `.github/workflows/ci.yml`, insert:

```yml
permissions:
  contents: read
```

right after the `concurrency` block (or near top-level keys before `jobs`). This grants only repository read access to `GITHUB_TOKEN`, which is sufficient for checkout and CI tasks shown.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
