### PR TITLE
Fix: Hotwire reload error after update to v2

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -11,7 +11,6 @@
 <meta name="view-transition" content="same-origin">
 <meta name="turbo-cache-control" content="no-cache">
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
-<%= hotwire_livereload_tags if Rails.env.development? %>
 
 <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module", defer: true %>
 <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
I had this error

```
Showing /usr/src/app/app/views/layouts/_head.html.erb where line #14 raised: undefined local variable or method 'hotwire_livereload_tags' for an instance of #<Class:0x00007ffa14eac1d8>
```

while running locally

afaict this has been removed in hotwire reload v2

https://github.com/kirillplatonov/hotwire-livereload/commit/2a549a4dbccc32c9d721338d267740873ef2c0b4